### PR TITLE
Chore: Fix Task/UserStory/EPIC Issue Templates (add Sub-issue sections)

### DIFF
--- a/.github/ISSUE_TEMPLATE/_legacy/epic.yml
+++ b/.github/ISSUE_TEMPLATE/_legacy/epic.yml
@@ -1,5 +1,4 @@
 name: Epic
-hidden: true
 description: Create a high-level container issue (Epic)
 title: "[EPIC] "
 labels: ["EPIC"]

--- a/.github/ISSUE_TEMPLATE/_legacy/task.yml
+++ b/.github/ISSUE_TEMPLATE/_legacy/task.yml
@@ -1,5 +1,4 @@
 name: Task
-hidden: true
 description: Create a technical sub-task linked to a User Story
 title: "Task: "
 labels: ["TASK"]

--- a/.github/ISSUE_TEMPLATE/_legacy/user-story.yml
+++ b/.github/ISSUE_TEMPLATE/_legacy/user-story.yml
@@ -1,5 +1,4 @@
 name: User Story
-hidden: true
 description: Create an assignable User Story
 title: "User Story: "
 labels: ["USER STORY"]


### PR DESCRIPTION
Fixed conflict the New & Old Templates have the same name

- GitHub Templates doesn`t support (hidden : true) for old Templates
- move old Templates to ./_legacy