### PR TITLE
Fix: Backend Update settings launchSettings.json

### DIFF
--- a/src/backend/Properties/launchSettings.json
+++ b/src/backend/Properties/launchSettings.json
@@ -1,20 +1,12 @@
 ﻿{
   "$schema": "http://json.schemastore.org/launchsettings.json",
-  "iisSettings": {
-    "windowsAuthentication": false,
-    "anonymousAuthentication": true,
-    "iisExpress": {
-      "applicationUrl": "http://localhost:42557",
-      "sslPort": 44385
-    }
-  },
   "profiles": {
     "backend": {
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": true,
       "launchUrl": "swagger",
-      "applicationUrl": "https://localhost:5001;http://localhost:5000",
+      "applicationUrl": "http://localhost:5000",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }


### PR DESCRIPTION
Update settings launchSettings.json

 - отключение старта IIS (т.к. Kestrel)
 -  Kestrel порт 5000
     - DEV: без HTTPS, чтобы не конфликтовать с Vite
     - PROD: TLS на прокси, Kestrel — только HTTP внутри