### PR TITLE
Feature #66: API: метод получения списка курсов

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,6 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
+    <PackageVersion Include="AutoFixture.AutoMoq" Version="4.18.1" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.1" />
     <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.4" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="8.0.4" />
@@ -19,6 +20,7 @@
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="8.0.8" />
     <PackageVersion Include="Microsoft.IdentityModel.Tokens" Version="8.0.1" />
+    <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.4" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.6.2" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.0.1" />

--- a/src/backend/Api/Controllers/CoursesController.cs
+++ b/src/backend/Api/Controllers/CoursesController.cs
@@ -23,19 +23,16 @@ public class CoursesController : ControllerBase
     /// Возвращает коллекцию курсов. Если курсы не найдены возвращает пустую коллекцию
     /// </returns>
     [HttpGet]
-    [ProducesResponseType(typeof(IEnumerable<CourseShortResponse>), StatusCodes.Status200OK)]
-    public async Task<ActionResult<IEnumerable<CourseShortResponse>>> GetAll()
+    [ProducesResponseType(typeof(IEnumerable<CourseDto>), StatusCodes.Status200OK)]
+    public async Task<ActionResult<IEnumerable<CourseDto>>> GetAll()
     {
         IEnumerable<CourseDto>? courses = await _service.GetAllAsync();
 
         if (courses is null)
         {
-            return Ok(Array.Empty<CourseShortResponse>());
+            return Ok(Array.Empty<CourseDto>());
         }
 
-        var coursesResponse = courses
-            .Select(c => new CourseShortResponse(c.Id, c.Title, c?.Description));
-
-        return Ok(coursesResponse);
+        return Ok(courses);
     }
 }

--- a/src/backend/Api/Controllers/CoursesController.cs
+++ b/src/backend/Api/Controllers/CoursesController.cs
@@ -24,7 +24,6 @@ public class CoursesController : ControllerBase
     /// </returns>
     [HttpGet]
     [ProducesResponseType(typeof(IEnumerable<CourseDto>), StatusCodes.Status200OK)]
-    [ProducesResponseType(typeof(ResponseDtoBase), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<IEnumerable<CourseDto>>> GetAll()
     {
         IEnumerable<CourseDto>? courses = await _service.GetAllAsync();

--- a/src/backend/Api/Controllers/CoursesController.cs
+++ b/src/backend/Api/Controllers/CoursesController.cs
@@ -23,16 +23,19 @@ public class CoursesController : ControllerBase
     /// Возвращает коллекцию курсов. Если курсы не найдены возвращает пустую коллекцию
     /// </returns>
     [HttpGet]
-    [ProducesResponseType(typeof(IEnumerable<CourseDto>), StatusCodes.Status200OK)]
-    public async Task<ActionResult<IEnumerable<CourseDto>>> GetAll()
+    [ProducesResponseType(typeof(IEnumerable<CourseShortResponse>), StatusCodes.Status200OK)]
+    public async Task<ActionResult<IEnumerable<CourseShortResponse>>> GetAll()
     {
         IEnumerable<CourseDto>? courses = await _service.GetAllAsync();
 
         if (courses is null)
         {
-            return Ok(Array.Empty<CourseDto>());
+            return Ok(Array.Empty<CourseShortResponse>());
         }
 
-        return Ok(courses);
+        var coursesResponse = courses
+            .Select(c => new CourseShortResponse(c.Id, c.Title, c?.Description));
+
+        return Ok(coursesResponse);
     }
 }

--- a/src/backend/Api/Controllers/CoursesController.cs
+++ b/src/backend/Api/Controllers/CoursesController.cs
@@ -1,0 +1,39 @@
+﻿using Api.Models;
+using Application.Abstractions.Services;
+using Application.Dto.Course;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Api.Controllers;
+
+[ApiController]
+[Produces("application/json")]
+[Route("api/[controller]")]
+public class CoursesController : ControllerBase
+{
+    private readonly ICourseService _service;
+    public CoursesController(ICourseService service)
+    {
+        _service = service;
+    }
+
+    /// <summary>
+    /// Получить все доступные курсы
+    /// </summary>
+    /// <returns>
+    /// Возвращает коллекцию курсов. Если курсы не найдены возвращает пустую коллекцию
+    /// </returns>
+    [HttpGet]
+    [ProducesResponseType(typeof(IEnumerable<CourseDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ResponseDtoBase), StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult<IEnumerable<CourseDto>>> GetAll()
+    {
+        IEnumerable<CourseDto>? courses = await _service.GetAllAsync();
+
+        if (courses is null)
+        {
+            return Ok(Array.Empty<CourseDto>());
+        }
+
+        return Ok(courses);
+    }
+}

--- a/src/backend/Application/Abstractions/Services/ICourseService.cs
+++ b/src/backend/Application/Abstractions/Services/ICourseService.cs
@@ -1,0 +1,8 @@
+﻿using Application.Dto.Course;
+
+namespace Application.Abstractions.Services;
+
+public interface ICourseService
+{
+    Task<IEnumerable<CourseDto>> GetAllAsync();
+}

--- a/src/backend/Application/ApplicationDI.cs
+++ b/src/backend/Application/ApplicationDI.cs
@@ -1,4 +1,5 @@
 using Application.Abstractions.Services;
+using Application.UseCases.Course;
 using Application.UseCasesTester;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -9,6 +10,7 @@ public static class ApplicationDI
     public static IServiceCollection AddApplication(this IServiceCollection services)
     {
         services.AddScoped<ITesterService, TesterService>();
+        services.AddScoped<ICourseService, CourseService>();
         return services;
     }
 }

--- a/src/backend/Application/Dto/Course/CourseDto.cs
+++ b/src/backend/Application/Dto/Course/CourseDto.cs
@@ -7,6 +7,4 @@
 /// <param name="Title">Название курса</param>
 /// <param name="Code">Код курса</param>
 /// <param name="Description">Описание курса</param>
-/// <param name="CreatedAt">Дата и время создания курса</param>
-/// <param name="UpdatedAt">Дата и время последнего обновления курса</param>
-public record CourseDto(Guid Id, string Title, string? Code, string? Description, DateTime? CreatedAt, DateTime? UpdatedAt);
+public record CourseDto(Guid Id, string Title, string? Code, string? Description);

--- a/src/backend/Application/Dto/Course/CourseDto.cs
+++ b/src/backend/Application/Dto/Course/CourseDto.cs
@@ -1,0 +1,9 @@
+﻿namespace Application.Dto.Course;
+
+/// <summary>
+/// CourseDto транспортный объект (data transfer)
+/// </summary>
+/// <param name="Id">Id курса</param>
+/// <param name="Title">Название курса</param>
+/// <param name="Description">Описание курса</param>
+public record CourseDto(Guid Id, string Title, string Description);

--- a/src/backend/Application/Dto/Course/CourseDto.cs
+++ b/src/backend/Application/Dto/Course/CourseDto.cs
@@ -5,5 +5,8 @@
 /// </summary>
 /// <param name="Id">Id курса</param>
 /// <param name="Title">Название курса</param>
+/// <param name="Code">Код курса</param>
 /// <param name="Description">Описание курса</param>
-public record CourseDto(Guid Id, string Title, string Description);
+/// <param name="CreatedAt">Дата и время создания курса</param>
+/// <param name="UpdatedAt">Дата и время последнего обновления курса</param>
+public record CourseDto(Guid Id, string Title, string? Code, string? Description, DateTime? CreatedAt, DateTime? UpdatedAt);

--- a/src/backend/Application/Dto/Course/CourseShortResponse.cs
+++ b/src/backend/Application/Dto/Course/CourseShortResponse.cs
@@ -1,9 +1,0 @@
-﻿namespace Application.Dto.Course;
-
-/// <summary>
-/// CourseDto транспортный объект (data transfer)
-/// </summary>
-/// <param name="Id">Id курса</param>
-/// <param name="Title">Название курса</param>
-/// <param name="Description">Описание курса</param>
-public record CourseShortResponse(Guid Id, string Title, string? Description);

--- a/src/backend/Application/Dto/Course/CourseShortResponse.cs
+++ b/src/backend/Application/Dto/Course/CourseShortResponse.cs
@@ -1,0 +1,9 @@
+﻿namespace Application.Dto.Course;
+
+/// <summary>
+/// CourseDto транспортный объект (data transfer)
+/// </summary>
+/// <param name="Id">Id курса</param>
+/// <param name="Title">Название курса</param>
+/// <param name="Description">Описание курса</param>
+public record CourseShortResponse(Guid Id, string Title, string? Description);

--- a/src/backend/Application/Models/Course.cs
+++ b/src/backend/Application/Models/Course.cs
@@ -1,0 +1,9 @@
+﻿namespace Application.Models;
+
+/// <summary>
+/// Модель курса (domain/application level)
+/// </summary>
+/// <param name="Id">Id курса</param>
+/// <param name="Title">Название курса</param>
+/// <param name="Description">Описание курса</param>
+public record Course(Guid Id, string Title, string Description);

--- a/src/backend/Application/Models/Course.cs
+++ b/src/backend/Application/Models/Course.cs
@@ -5,5 +5,8 @@
 /// </summary>
 /// <param name="Id">Id курса</param>
 /// <param name="Title">Название курса</param>
+/// <param name="Code">Код курса</param>
 /// <param name="Description">Описание курса</param>
-public record Course(Guid Id, string Title, string Description);
+/// <param name="CreatedAt">Дата и время создания курса</param>
+/// <param name="UpdatedAt">Дата и время последнего обновления курса</param>
+public record Course(Guid Id, string Title, string? Code, string? Description, DateTime? CreatedAt, DateTime? UpdatedAt);

--- a/src/backend/Application/UseCases/Course/CourseService.cs
+++ b/src/backend/Application/UseCases/Course/CourseService.cs
@@ -9,8 +9,8 @@ public class CourseService : ICourseService
     {
         IEnumerable<CourseDto> demo = new[]
         {
-            new CourseDto(Guid.NewGuid(), "C# Basics", "Intro to C#"),
-            new CourseDto(Guid.NewGuid(), "Unity Intro", "GameDev basics")
+            new CourseDto(Guid.NewGuid(), "C# Basics", "CS101", "Intro to C#", DateTime.Now, null),
+            new CourseDto(Guid.NewGuid(), "Unity Intro", "UN201", "GameDev basics", DateTime.Now, null)
         };
 
         return Task.FromResult(demo);

--- a/src/backend/Application/UseCases/Course/CourseService.cs
+++ b/src/backend/Application/UseCases/Course/CourseService.cs
@@ -7,8 +7,12 @@ public class CourseService : ICourseService
 {
     public Task<IEnumerable<CourseDto>> GetAllAsync()
     {
-        //throw new NotImplementedException();
-        // TODO: https://github.com/DSivtsov/SeaWind/issues/67
-        return Task.FromResult<IEnumerable<CourseDto>>(Array.Empty<CourseDto>());
+        IEnumerable<CourseDto> demo = new[]
+        {
+            new CourseDto(Guid.NewGuid(), "C# Basics", "Intro to C#"),
+            new CourseDto(Guid.NewGuid(), "Unity Intro", "GameDev basics")
+        };
+
+        return Task.FromResult(demo);
     }
 }

--- a/src/backend/Application/UseCases/Course/CourseService.cs
+++ b/src/backend/Application/UseCases/Course/CourseService.cs
@@ -1,0 +1,14 @@
+﻿using Application.Abstractions.Services;
+using Application.Dto.Course;
+
+namespace Application.UseCases.Course;
+
+public class CourseService : ICourseService
+{
+    public Task<IEnumerable<CourseDto>> GetAllAsync()
+    {
+        //throw new NotImplementedException();
+        // TODO: https://github.com/DSivtsov/SeaWind/issues/67
+        return Task.FromResult<IEnumerable<CourseDto>>(Array.Empty<CourseDto>());
+    }
+}

--- a/src/backend/Application/UseCases/Course/CourseService.cs
+++ b/src/backend/Application/UseCases/Course/CourseService.cs
@@ -9,8 +9,8 @@ public class CourseService : ICourseService
     {
         IEnumerable<CourseDto> demo = new[]
         {
-            new CourseDto(Guid.NewGuid(), "C# Basics", "CS101", "Intro to C#", DateTime.Now, null),
-            new CourseDto(Guid.NewGuid(), "Unity Intro", "UN201", "GameDev basics", DateTime.Now, null)
+            new CourseDto(Guid.NewGuid(), "C# Basics", "CS101", "Intro to C#"),
+            new CourseDto(Guid.NewGuid(), "Unity Intro", "UN201", "GameDev basics")
         };
 
         return Task.FromResult(demo);

--- a/tests/Api.UnitTests/Api.UnitTests.csproj
+++ b/tests/Api.UnitTests/Api.UnitTests.csproj
@@ -8,12 +8,18 @@
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="AutoFixture.AutoMoq" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
     <PackageReference Include="xunit" />
 	<PackageReference Include="xunit.runner.visualstudio">
 		<PrivateAssets>all</PrivateAssets>
 	</PackageReference>
 	<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\backend\Api\Api.csproj" />
+    <ProjectReference Include="..\..\src\backend\Application\Application.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Using Include="Xunit" />

--- a/tests/Api.UnitTests/Controllers/CoursesController.Tests.cs
+++ b/tests/Api.UnitTests/Controllers/CoursesController.Tests.cs
@@ -22,7 +22,7 @@ public class CoursesControllerTests
     }
 
     /// <summary>
-    /// Проверяет, что GetAll контроллера возвращает OkObjectResult, содержащий коллекцию объектов CourseDto, когда курсы доступны.
+    /// Проверяет, что GetAll контроллера возвращает OkObjectResult, содержащий коллекцию объектов CourseShortResponse, когда курсы доступны.
     /// </summary>
     /// <remarks>
     /// Этот тест гарантирует, что метод GetAll контроллера отвечает HTTP 200 OK 
@@ -46,7 +46,7 @@ public class CoursesControllerTests
 
         // Assert
         OkObjectResult coursesResultType = Assert.IsType<OkObjectResult>(actionResult.Result);
-        IEnumerable<CourseDto> coursesResult = Assert.IsAssignableFrom<IEnumerable<CourseDto>>(coursesResultType.Value);
+        IEnumerable<CourseShortResponse> coursesResult = Assert.IsAssignableFrom<IEnumerable<CourseShortResponse>>(coursesResultType.Value);
 
         Assert.Equal(countCourses, coursesResult.Count());
 
@@ -78,7 +78,7 @@ public class CoursesControllerTests
 
         // Assert
         OkObjectResult coursesResultType = Assert.IsType<OkObjectResult>(actionResult.Result);
-        IEnumerable<CourseDto> coursesResult = Assert.IsAssignableFrom<IEnumerable<CourseDto>>(coursesResultType.Value);
+        IEnumerable<CourseShortResponse> coursesResult = Assert.IsAssignableFrom<IEnumerable<CourseShortResponse>>(coursesResultType.Value);
 
         Assert.Empty(coursesResult);
     }

--- a/tests/Api.UnitTests/Controllers/CoursesController.Tests.cs
+++ b/tests/Api.UnitTests/Controllers/CoursesController.Tests.cs
@@ -22,7 +22,7 @@ public class CoursesControllerTests
     }
 
     /// <summary>
-    /// Проверяет, что GetAll контроллера возвращает OkObjectResult, содержащий коллекцию объектов CourseShortResponse, когда курсы доступны.
+    /// Проверяет, что GetAll контроллера возвращает OkObjectResult, содержащий коллекцию объектов CourseDto, когда курсы доступны.
     /// </summary>
     /// <remarks>
     /// Этот тест гарантирует, что метод GetAll контроллера отвечает HTTP 200 OK 
@@ -46,7 +46,7 @@ public class CoursesControllerTests
 
         // Assert
         OkObjectResult coursesResultType = Assert.IsType<OkObjectResult>(actionResult.Result);
-        IEnumerable<CourseShortResponse> coursesResult = Assert.IsAssignableFrom<IEnumerable<CourseShortResponse>>(coursesResultType.Value);
+        IEnumerable<CourseDto> coursesResult = Assert.IsAssignableFrom<IEnumerable<CourseDto>>(coursesResultType.Value);
 
         Assert.Equal(countCourses, coursesResult.Count());
 
@@ -78,7 +78,7 @@ public class CoursesControllerTests
 
         // Assert
         OkObjectResult coursesResultType = Assert.IsType<OkObjectResult>(actionResult.Result);
-        IEnumerable<CourseShortResponse> coursesResult = Assert.IsAssignableFrom<IEnumerable<CourseShortResponse>>(coursesResultType.Value);
+        IEnumerable<CourseDto> coursesResult = Assert.IsAssignableFrom<IEnumerable<CourseDto>>(coursesResultType.Value);
 
         Assert.Empty(coursesResult);
     }

--- a/tests/Api.UnitTests/Controllers/CoursesController.Tests.cs
+++ b/tests/Api.UnitTests/Controllers/CoursesController.Tests.cs
@@ -1,0 +1,85 @@
+﻿using Api.Controllers;
+using Application.Abstractions.Services;
+using Application.Dto.Course;
+using AutoFixture;
+using AutoFixture.AutoMoq;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+
+namespace Api.UnitTests.Controllers;
+
+public class CoursesControllerTests
+{
+    private readonly IFixture _fixture;
+    private readonly Mock<ICourseService> _courseServiceMock;
+    private readonly CoursesController _coursesController;
+
+    public CoursesControllerTests()
+    {
+        _fixture = new Fixture().Customize(new AutoMoqCustomization());
+        _courseServiceMock = _fixture.Freeze<Mock<ICourseService>>();
+        _coursesController = _fixture.Build<CoursesController>().OmitAutoProperties().Create();
+    }
+
+    /// <summary>
+    /// Проверяет, что GetAll контроллера возвращает OkObjectResult, содержащий коллекцию объектов CourseDto, когда курсы доступны.
+    /// </summary>
+    /// <remarks>
+    /// Этот тест гарантирует, что метод GetAll контроллера отвечает HTTP 200 OK 
+    /// и включает ожидаемое количество объектов курса с допустимыми свойствами.
+    /// Он проверяет как тип ответа, так и целостность возвращаемых данных.
+    /// </remarks>
+    /// <returns></returns>
+    [Fact]
+    public async Task GetAll_ReturnsOk_WithCourses()
+    {
+        // Arrange
+        int countCourses = 2;
+        IEnumerable<CourseDto> courses = _fixture
+            .Build<CourseDto>()
+            .CreateMany(countCourses);
+
+        _courseServiceMock.Setup(srv => srv.GetAllAsync()).ReturnsAsync(courses);
+
+        // Act
+        var actionResult = await _coursesController.GetAll();
+
+        // Assert
+        OkObjectResult coursesResultType = Assert.IsType<OkObjectResult>(actionResult.Result);
+        IEnumerable<CourseDto> coursesResult = Assert.IsAssignableFrom<IEnumerable<CourseDto>>(coursesResultType.Value);
+
+        Assert.Equal(countCourses, coursesResult.Count());
+
+        foreach (var course in coursesResult)
+        {
+            Assert.NotEqual(Guid.Empty, course.Id);
+            Assert.False(string.IsNullOrWhiteSpace(course.Title));
+            Assert.False(string.IsNullOrWhiteSpace(course.Description));
+        }
+    }
+
+
+    /// <summary>
+    /// Проверяет, что действие GetAll возвращает ответ HTTP 200 OK с пустым массивом, когда сервис возвращает значение NULL.
+    /// </summary>
+    /// <remarks>
+    /// Этот тест гарантирует, что контроллер нормализует нулевой результат службы в пустой массив в ответе, 
+    /// обеспечивая согласованное поведение API для клиентов.
+    /// </remarks>
+    /// <returns></returns>
+    [Fact]
+    public async Task GetAll_ReturnsOk_WithEmptyArray_WhenServiceReturnsNull()
+    {
+        // Arrange
+        _courseServiceMock.Setup(srv => srv.GetAllAsync()).ReturnsAsync(() => null!);
+
+        // Act
+        var actionResult = await _coursesController.GetAll();
+
+        // Assert
+        OkObjectResult coursesResultType = Assert.IsType<OkObjectResult>(actionResult.Result);
+        IEnumerable<CourseDto> coursesResult = Assert.IsAssignableFrom<IEnumerable<CourseDto>>(coursesResultType.Value);
+
+        Assert.Empty(coursesResult);
+    }
+}


### PR DESCRIPTION
Close #66

Что сделано:
- Реализован endpoint GET /api/courses для получения списка курсов с полями id, title, description.
- Описаны DTO In/Out, статусы ответов и добавлено в Swagger.
- Добавлены Api.UnitTest

Acceptance Criteria:
- Endpoint доступен без авторизации
- Возвращается список курсов с полями id, title, description
- Формат ответа JSON
- При отсутствии курсов возвращается пустой список
- Swagger показывает корректный контракт; при ошибках возвращаются соответствующие коды
- Все Api.UnitTest зеленые