### PR TITLE
Chore: Fix duplicate PKeys issue and improve seeding pipeline

### DIFF
--- a/src/backend/Api/Controllers/TestersController.cs
+++ b/src/backend/Api/Controllers/TestersController.cs
@@ -93,7 +93,7 @@ public sealed class TestersController : ControllerBase
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(FileResult))]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     [Produces("text/csv")]
-    public ActionResult<FileResult> ExportCsv([FromRoute] Guid id)
+    public IActionResult ExportCsv([FromRoute] Guid id)
     {
         var user = _svc.Get(id);
         if (user is null)

--- a/src/backend/Api/appsettings.Development.json.example
+++ b/src/backend/Api/appsettings.Development.json.example
@@ -15,6 +15,7 @@
     "Key": "DXaA1_usIbb-9txBxhqG36Hua0zXa2UWuXwafsFCfiA="
   },
   "Seed": {
+    "Preset": "SeedCustom", // "SeedOFF", "SeedCustom", "SuperFast", "Fast", "Real"
     "CoreOption": {
       "FileNameDataTemplate": "Demo{Entity}.json", // Пример для сущности Tester "DemoTester.json"
       "FileNameSeedTemplate": "Demo{Entity}.seed.json", // Пример для сущности Tester "DemoTester.seed.json"
@@ -23,7 +24,7 @@
     "TimeDbContext": {
       "Enabled": true,
       "PathBase": "Time/SeedData", // Проект by "CopyToOutputDirectory" копирует файлы с данными из проекта в рабочий каталог
-      "Mode": "InsertOrUpdate",
+      "Mode": "InsertOrUpdate", // InsertOnly/InsertOrUpdate
       //OPTION TURN OFF "PathVersion": "Time/SeedData/v1", 
       "UUID": "Real", // Stable/Real
       "ExistenData": "Fresh", // Fresh/NotDel

--- a/src/backend/Infrastructure.Postgres/DbSeeders.cs
+++ b/src/backend/Infrastructure.Postgres/DbSeeders.cs
@@ -26,6 +26,9 @@ public static class AddDbSeeders
         services.AddSingleton<ISeedCoreOptions, DefaultSeedCoreOptions>();
         services.AddSingleton<IPathFile, PathFile>();
 
+        // регистратор сервиса анализа престов сидирования
+        services.AddSingleton<SeedPresetAnalyzer>();
+
         // DI для интерфейса запуска сидирования 
         services.AddScoped<IMainRunnerSeeding, MainRunner>();
 

--- a/src/backend/Infrastructure.Postgres/Seeding/ContextDB/Options.cs
+++ b/src/backend/Infrastructure.Postgres/Seeding/ContextDB/Options.cs
@@ -9,7 +9,7 @@ internal sealed class Options<TContext> where TContext : DbContext
 {
     private const string OPTION_PATH_BASE = "PathBase";
     private const string OPTION_PATH_VERSION = "PathVersion";
-    private const string OPTION_INSERT_MODE = "InsertMode";
+    private const string OPTION_INSERT_MODE = "Mode";
     private const string OPTION_UUID = "UUID";
     private const string OPTION_EXISTEN_DATA = "ExistenData";
     private const string OPTION_AUTO_MIGRATE = "AutoMigrate";

--- a/src/backend/Infrastructure.Postgres/Seeding/ContextDB/Options.cs
+++ b/src/backend/Infrastructure.Postgres/Seeding/ContextDB/Options.cs
@@ -9,7 +9,8 @@ internal sealed class Options<TContext> where TContext : DbContext
 {
     private const string OPTION_PATH_BASE = "PathBase";
     private const string OPTION_PATH_VERSION = "PathVersion";
-    private const string OPTION_MODE = "Mode";
+    private const string OPTION_INSERT_MODE = "InsertMode";
+    private const string OPTION_UUID = "UUID";
     private const string OPTION_EXISTEN_DATA = "ExistenData";
     private const string OPTION_AUTO_MIGRATE = "AutoMigrate";
     private readonly ILogger _log;
@@ -27,48 +28,53 @@ internal sealed class Options<TContext> where TContext : DbContext
     {
         try
         {
-            var (existenData, mode, pathBase, pathVersion, autoMigrate) = GetSeedingOption();
+            var (existenData, mode, pathBase, pathVersion, autoMigrate, UUIDmode) = GetSeedingOption();
             _log.LogInformation("Seeding options for {Ctx}: ExistenData={ExistenData}, Mode={Mode}," +
-                " Base Path=[{PathBase}] Version Path=[{PathVersion}] AutoMigrate[{AutoMigrate}]",
+                " Base Path=[{PathBase}] Version Path=[{PathVersion}] AutoMigrate[{AutoMigrate}] UUIDmode[{UUIDmode}]",
                 typeof(TContext).Name, existenData, mode, pathBase,
-                string.IsNullOrWhiteSpace(pathVersion)? "None" : pathVersion, autoMigrate);
-            return new(true, existenData, mode, pathBase, pathVersion, autoMigrate);
+                string.IsNullOrWhiteSpace(pathVersion)? "None" : pathVersion, autoMigrate, UUIDmode);
+            return new(true, existenData, mode, pathBase, pathVersion, autoMigrate, UUIDmode);
         }
         catch (DirectoryNotFoundException ex)
         {
             _log.LogError(ex, "Path not found for {Ctx}", typeof(TContext).Name);
-            return new(false, default, default, "", "", false, ex.Message);
+            return new(false, default, default, "", "", false, default, ex.Message);
         }
         catch (InvalidOperationException ex)
         {
             _log.LogError(ex, "Invalid seeding options for {Ctx}", typeof(TContext).Name);
-            return new(false, default, default, "", "", false, ex.Message);
+            return new(false, default, default, "", "", false, default, ex.Message);
         }
     }
 
-    private (ExistenData existenData, SeedMode mode, string pathBase, string pathVersion,
-        bool autoMigrate) GetSeedingOption()
+    private (ExistenData existenData, SeedInsertMode mode, string pathBase, string pathVersion,
+        bool autoMigrate, UUIDMode UUIDmode) GetSeedingOption()
     {
         var pathBaseRel = _cfg[_prefix + OPTION_PATH_BASE];
         //var pathVersionRel = _cfg[_prefix + OPTION_PATH_VERSION];
-        var modeText = _cfg[_prefix + OPTION_MODE];
+        var insertModeText = _cfg[_prefix + OPTION_INSERT_MODE];
         var existenDataText = _cfg[_prefix + OPTION_EXISTEN_DATA];
         var autoMigrateText = _cfg[_prefix + OPTION_AUTO_MIGRATE];
+        var UUIDText = _cfg[_prefix + OPTION_UUID];
 
         if (string.IsNullOrWhiteSpace(pathBaseRel))
-            throw new InvalidOperationException($"{_prefix}Path is required");
+            throw new InvalidOperationException($"[{_prefix}{OPTION_PATH_BASE}] is required");
 
-        if (!Enum.TryParse(modeText, ignoreCase: true, out SeedMode mode))
-            throw new InvalidOperationException($"{_prefix}Mode is invalid: '{modeText}'" +
+        if (!Enum.TryParse(insertModeText, ignoreCase: true, out SeedInsertMode mode))
+            throw new InvalidOperationException($"[{_prefix}{OPTION_INSERT_MODE}] value is invalid: '{insertModeText}'" +
                 $" (use InsertOnly|InsertOrUpdate)");
 
         if (!Enum.TryParse(existenDataText, ignoreCase: true, out ExistenData existenData))
-            throw new InvalidOperationException($"{_prefix}ExistenData value is invalid: '{existenDataText}'" +
+            throw new InvalidOperationException($"[{_prefix}{OPTION_EXISTEN_DATA}] value is invalid: '{existenDataText}'" +
                 $" (use Fresh|NotDel)");
 
         if (!Boolean.TryParse(autoMigrateText, out bool autoMigrate))
-            throw new InvalidOperationException($"{_prefix}AutoMigrate value is invalid: '{autoMigrateText}'" +
+            throw new InvalidOperationException($"[{_prefix}{OPTION_AUTO_MIGRATE}] value is invalid: '{autoMigrateText}'" +
                 $" (use true|false)");
+
+        if (!Enum.TryParse(UUIDText, ignoreCase: true, out UUIDMode UUIDmode))
+            throw new InvalidOperationException($"[{_prefix}{OPTION_UUID}] value is invalid: '{UUIDText}'" +
+                $" (use Stable|Real)");
 
         var baseDir = AppContext.BaseDirectory;
 
@@ -85,6 +91,6 @@ internal sealed class Options<TContext> where TContext : DbContext
         //        pathVersion = string.Empty;
         //}
 
-        return (existenData, mode, pathBase, pathVersion, autoMigrate);
+        return (existenData, mode, pathBase, pathVersion, autoMigrate, UUIDmode);
     }
 }

--- a/src/backend/Infrastructure.Postgres/Seeding/ContextDB/Seeder.cs
+++ b/src/backend/Infrastructure.Postgres/Seeding/ContextDB/Seeder.cs
@@ -20,7 +20,7 @@ internal sealed class Seeder<TContext> where TContext : DbContext
 
     internal async Task RunSeedingAsync(OptionsResult optRez, ILogger logSeeder, CancellationToken ct = default)
     {
-        SeedMode mode = optRez.Mode;
+        SeedInsertMode insertMode = optRez.InsertMode;
         string pathBase = optRez.PathBase;
         string pathVersion = optRez.PathVersion;
 
@@ -68,7 +68,7 @@ internal sealed class Seeder<TContext> where TContext : DbContext
             await using var tx = await _dbContext.Database.BeginTransactionAsync(ct);
             try
             {
-                var result = await seeder.SeedAsync(_dbContext, mode, ct);
+                var result = await seeder.SeedAsync(_dbContext, insertMode, ct);
 
                 if (!result.ok)
                 {

--- a/src/backend/Infrastructure.Postgres/Seeding/MainRunner.cs
+++ b/src/backend/Infrastructure.Postgres/Seeding/MainRunner.cs
@@ -13,20 +13,30 @@ public interface IMainRunnerSeeding
 internal sealed class MainRunner : IMainRunnerSeeding
 {
     private readonly IEnumerable<IDbContextRunner> _runners;
-    readonly private IOptions<SeedCoreParameters> _coreOpt;
-    readonly private ILogger<MainRunner> _logger;
+    private readonly IOptions<SeedCoreParameters> _coreOpt;
+    private readonly ILogger<MainRunner> _logger;
+    private readonly SeedPresetAnalyzer _seedPresetAnalyzer;
+
 
     public MainRunner(IEnumerable<IDbContextRunner> runners,
                     IOptions<SeedCoreParameters> coreOpt,
-                    ILogger<MainRunner> logger)
+                    ILogger<MainRunner> logger,
+                    SeedPresetAnalyzer seedPresetAnalyzer)
     {
         _runners = runners;
         _coreOpt = coreOpt;
         _logger = logger;
+        _seedPresetAnalyzer = seedPresetAnalyzer;
     }
 
     public async Task Run(CancellationToken ct = default)
     {
+        if (_seedPresetAnalyzer.GetAndCheckIsSeedOff())
+        {
+            _logger.LogInformation("[SEEDING OFF]");
+            return;
+        }
+
         _logger.LogInformation("[SEEDING START]");
 
         SeedCoreParameters coreValues;

--- a/src/backend/Infrastructure.Postgres/Seeding/RunnerContextDB.cs
+++ b/src/backend/Infrastructure.Postgres/Seeding/RunnerContextDB.cs
@@ -49,6 +49,9 @@ internal sealed class RunnerContextDB<TContext> : IDbContextRunner where TContex
             return false;
         }
 
+        var seedPresetAnalyzer = _serviceProvider.GetRequiredService<SeedPresetAnalyzer>(); ;
+        optRez = seedPresetAnalyzer.ApplySeedPreset(optRez);
+
         var runnerSeedDataFiles = new RunnerSeedDataFiles(_logSeeder);
         var rezOk = runnerSeedDataFiles.Run(optRez.PathBase, optRez.UUIDmode);
         if (!rezOk)
@@ -84,6 +87,9 @@ internal sealed class RunnerContextDB<TContext> : IDbContextRunner where TContex
             return false;
         }
 
+        var seedUUIDStateChecher = new SeedUUIDStateChecker(_logSeeder, optRez, seedPresetAnalyzer.IsOptionsUnderFullManualControl);
+        optRez = seedUUIDStateChecher.FreshExistenDataIfNeed();
+
         if (optRez.ExistenData == ExistenData.Fresh)
         {
             var cleaner = _serviceProvider.GetRequiredService<Cleaner<TContext>>();
@@ -92,6 +98,8 @@ internal sealed class RunnerContextDB<TContext> : IDbContextRunner where TContex
 
         var seeder = _serviceProvider.GetRequiredService<Seeder<TContext>>();
         await seeder.RunSeedingAsync(optRez, _logSeeder, ct);
+
+        seedUUIDStateChecher.StoreCurrentUsedSeedUUID();
 
         return true;
     }

--- a/src/backend/Infrastructure.Postgres/Seeding/RunnerContextDB.cs
+++ b/src/backend/Infrastructure.Postgres/Seeding/RunnerContextDB.cs
@@ -50,7 +50,7 @@ internal sealed class RunnerContextDB<TContext> : IDbContextRunner where TContex
         }
 
         var runnerSeedDataFiles = new RunnerSeedDataFiles(_logSeeder);
-        var rezOk = runnerSeedDataFiles.Run(optRez.PathBase, UUIDMode.Real);
+        var rezOk = runnerSeedDataFiles.Run(optRez.PathBase, optRez.UUIDmode);
         if (!rezOk)
         {
             _logSeeder.LogError("Abort Seeding. Error in DataFiles.");

--- a/src/backend/Infrastructure.Postgres/Seeding/SeedDataFiles/DataFileWriter.cs
+++ b/src/backend/Infrastructure.Postgres/Seeding/SeedDataFiles/DataFileWriter.cs
@@ -1,0 +1,56 @@
+﻿using System.Text.Json;
+
+namespace Infrastructure.Postgres.Seeding.SeedDataFiles;
+
+internal class DataFileWriter : IDisposable
+{
+    private readonly Utf8JsonWriter _writer;
+    private readonly FileStream _fs;
+
+    private static JsonWriterOptions _jsonOptions = new JsonWriterOptions
+    {
+        Indented = true,
+        Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+    };
+
+    internal DataFileWriter(string fileName)
+    {
+        _fs = File.Create(fileName);
+        _writer = new Utf8JsonWriter(_fs, _jsonOptions);
+    }
+
+    internal void BeginWriteFile()
+    {
+        _writer.WriteStartArray();
+    }
+
+    internal void EndWriteFile()
+    {
+        _writer.WriteEndArray();
+        _writer.Flush();
+    }
+
+    internal void WriteJsonObject(List<(string Name, JsonElement Value)> buffer)
+    {
+        _writer.WriteStartObject();
+        foreach ((string name, JsonElement value) in buffer)
+        {
+            _writer.WritePropertyName(name);
+            value.WriteTo(_writer);
+        }
+        _writer.WriteEndObject();
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            _writer?.Flush();
+        }
+        finally
+        {
+            _writer.Dispose();
+            _fs.Dispose();
+        }
+    }
+}

--- a/src/backend/Infrastructure.Postgres/Seeding/SeedDataFiles/PrimaryKeyGuidGenerator.cs
+++ b/src/backend/Infrastructure.Postgres/Seeding/SeedDataFiles/PrimaryKeyGuidGenerator.cs
@@ -15,6 +15,8 @@ internal class PrimaryKeyGuidGenerator
 
     internal Guid GetGuid(string key) => _finalGuid[key];
 
+    internal bool TryGetGuid(string key, out Guid guid) => _finalGuid.TryGetValue(key, out guid);
+
     internal void Generate(IReadOnlyDictionary<string, Guid> pKeysRaw)
     {
         _finalGuid = _modeUUID switch

--- a/src/backend/Infrastructure.Postgres/Seeding/SeedDataFiles/RunnerSeedDataFiles.cs
+++ b/src/backend/Infrastructure.Postgres/Seeding/SeedDataFiles/RunnerSeedDataFiles.cs
@@ -48,7 +48,7 @@ namespace Infrastructure.Postgres.Seeding.SeedDataFiles
             var pKeysGuid = new PrimaryKeyGuidGenerator(modeUUID);
             pKeysGuid.Generate(tableAnalysis.PKeys);
 
-            var outputSeedDataFiles = new SeedFilesOutputGenerator(pKeysGuid, tableAnalysis.FKeys, tableAnalysis.RootJsonElementsEntities);
+            var outputSeedDataFiles = new SeedFilesOutputGenerator(pKeysGuid, tableAnalysis.RootJsonElementsEntities);
             outputSeedDataFiles.Generate();
 
             return true;

--- a/src/backend/Infrastructure.Postgres/Seeding/SeedDataFiles/SeedFilesAnalyzer.cs
+++ b/src/backend/Infrastructure.Postgres/Seeding/SeedDataFiles/SeedFilesAnalyzer.cs
@@ -26,9 +26,9 @@ namespace Infrastructure.Postgres.Seeding.SeedDataFiles
                 ParseAndScanSeedFile(path);
             }
 
-            List<string> validationWarnings = ValidateFkeys();
+            List<string> validationWarnings = DetectedWarnings();
 
-            return new TableAnalysis(_dictPKeyGuid, _hashFKeyFileName, _rootJsonElementsEntities, validationWarnings);
+            return new TableAnalysis(_dictPKeyGuid, _rootJsonElementsEntities, validationWarnings);
         }
 
         private void ParseAndScanSeedFile(string pathfile)
@@ -89,8 +89,16 @@ namespace Infrastructure.Postgres.Seeding.SeedDataFiles
             }
         }
 
-
-        private List<string> ValidateFkeys()
+        /// <summary>
+        /// Анализирует собранные данные и формирует список предупреждений (Warnings):
+        /// дублирующиеся PKey и FKey, для которых отсутствуют соответствующие PKey.
+        /// <para/>
+        /// Эти проблемы не приводят к исключению — они будут автоматически
+        /// устранены при генерации выходных файлов в
+        /// SeedFilesOutputGenerator.GenerateJsonObject().
+        /// </summary>
+        /// <returns>Список текстовых предупреждений.</returns>
+        private List<string> DetectedWarnings()
         {
             List<string> validationWarnings = new List<string>();
 
@@ -98,22 +106,17 @@ namespace Infrastructure.Postgres.Seeding.SeedDataFiles
             {
                 foreach ((string pKey, string fileName) item in _listDublicatePK)
                 {
-                    validationWarnings.Add($"Skipped record with duplicate PKey[{item.pKey}] in file [{item.fileName}]");
+                    validationWarnings.Add($"Will Skipped record with duplicate PKey[{item.pKey}] in file [{item.fileName}]");
                 }
             }
 
-            List<(string fKey, string fileName)> recToDel = new();
             foreach ((string fKey, string fileName) item in _hashFKeyFileName)
             {
                 if (!_dictPKeyGuid.ContainsKey(item.fKey))
                 {
-                    validationWarnings.Add($"Skipped record with invalid FKey[{item.fKey}] in file [{item.fileName}]");
-                    recToDel.Add(item);
+                    validationWarnings.Add($"Will Skipped record with invalid FKey[{item.fKey}] in file [{item.fileName}]");
                 }
             }
-
-            foreach (var rec in recToDel)
-                _hashFKeyFileName.Remove(rec);
 
             return validationWarnings;
         }

--- a/src/backend/Infrastructure.Postgres/Seeding/SeedDataFiles/SeedFilesOutputGenerator.cs
+++ b/src/backend/Infrastructure.Postgres/Seeding/SeedDataFiles/SeedFilesOutputGenerator.cs
@@ -5,150 +5,39 @@ namespace Infrastructure.Postgres.Seeding.SeedDataFiles
     internal class SeedFilesOutputGenerator
     {
         private readonly PrimaryKeyGuidGenerator _finalGuid;
-        private readonly IReadOnlySet<(string fKey, string fileName)> _hashFKeyFileName;
         private readonly IReadOnlyCollection<(string entityName, JsonElement rootElement)> _rootJsonElementsEntities;
 
-        private string? _currentEntityName;
-        private HelperSeedFilesChecker? _seedFilesChecker;
-        private readonly List<(string Name, JsonElement Value)> _buffer = new();
-        private Action<JsonElement>? _actionsForJsonObject;
-        private readonly HashSet<string> _hashPkKeyExist = new();
+        private readonly HashSet<string> _existPKeys = new();
 
-        private Utf8JsonWriter? _timeWriter;
-
-        internal SeedFilesOutputGenerator(PrimaryKeyGuidGenerator finalGuid, IReadOnlySet<(string fKey, string fileName)> fKeys,
+        internal SeedFilesOutputGenerator(PrimaryKeyGuidGenerator finalGuid,
             IReadOnlyCollection<(string entityName, JsonElement rootElement)> rootJsonElementsEntities)
         {
             _finalGuid = finalGuid ?? throw new ArgumentNullException(nameof(finalGuid));
-            _hashFKeyFileName = fKeys ?? throw new ArgumentNullException(nameof(fKeys));
             _rootJsonElementsEntities = rootJsonElementsEntities ?? throw new ArgumentNullException(nameof(rootJsonElementsEntities));
         }
-
-        private static JsonWriterOptions _jsonOptions = new JsonWriterOptions
-        {
-            Indented = true,
-            Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping
-        };
 
         internal void Generate()
         {
             foreach ((string entityName, JsonElement rootElement) item in _rootJsonElementsEntities)
             {
-                _currentEntityName = item.entityName;
-
-                _seedFilesChecker = new HelperSeedFilesChecker(_currentEntityName);
-
-                CreateDataFile(item.rootElement); /// with SaveData
+                CreateDataFileForEntity(item.entityName, item.rootElement);
             }
         }
 
-        private string GetNameCurrentDataFile()
+        private void CreateDataFileForEntity(string entityName, JsonElement rootElement)
         {
-            ReadOnlySpan<char> name = _currentEntityName;
-            if (name.Length == 0)
-                throw new InvalidOperationException("Entity name cannot be empty.");
+            var currentFileName = GetNameCurrentDataFile(entityName);
 
-            string Name = name.Length == 1
-                ? char.ToUpperInvariant(name[0]).ToString()
-                : string.Concat(char.ToUpperInvariant(name[0]), name[1..].ToString());
+            using var currentWriter = new DataFileWriter(currentFileName);
 
-            return $"Demo{Name}.json";
+            currentWriter.BeginWriteFile();
+
+            WriteJsonElement(entityName, currentWriter, rootElement);
+
+            currentWriter.EndWriteFile();
         }
 
-        private void CreateDataFile(JsonElement rootElement)
-        {
-            var currentFileName = GetNameCurrentDataFile();
-
-            using var fs = File.Create(currentFileName);
-            using var writer = new Utf8JsonWriter(fs, _jsonOptions);
-            _timeWriter = writer;
-            writer.WriteStartArray();
-
-            ParseSeedFileAndSaveData(rootElement);
-
-            writer.WriteEndArray();
-            writer.Flush();
-
-        }
-
-        private void ParseSeedFileAndSaveData(JsonElement rootElement)
-        {
-            _actionsForJsonObject = PrepareDataFile;
-
-            ParseJsonArray(rootElement); /// with ParseAndScan
-        }
-
-        private bool FillBufferJsonObject(JsonElement jsonObject)
-        {
-            // цикл по полям объекта
-            foreach (JsonProperty property in jsonObject.EnumerateObject())
-            {
-                JsonElement jsonValue = property.Value;
-
-                if (jsonValue.ValueKind == JsonValueKind.Object || jsonValue.ValueKind == JsonValueKind.Array)
-                {
-                    _buffer.Add((property.Name, jsonValue));
-                    continue;
-                }
-
-                string value = jsonValue.ToString();
-                var typeKey = _seedFilesChecker?.GetKeyType(value);
-                switch (typeKey)
-                {
-                    case TypeKey.NotKey:
-                        _buffer.Add((property.Name, jsonValue));
-                        continue;
-
-                    case TypeKey.PK:
-                        if (_hashPkKeyExist.Contains(value))
-                        {
-                            return false;
-                        }
-                        else
-                        {
-                            _buffer.Add((property.Name, JsonElementGUID(value)));
-                            continue;
-                        }
-
-                    case TypeKey.FK:
-                        if (_hashFKeyFileName.Contains((value, _currentEntityName!)))
-                        {
-                            _buffer.Add((property.Name, JsonElementGUID(value)));
-                            continue;
-                        }
-                        else
-                            return false;
-                }
-            }
-
-            return true;
-        }
-
-        private void PrepareDataFile(JsonElement jsonObject)
-        {
-            if (_timeWriter == null)
-                throw new NotImplementedException();
-
-            var addCurrentObject = FillBufferJsonObject(jsonObject);
-
-            if (addCurrentObject)
-            {
-                _timeWriter.WriteStartObject();
-                foreach ((string name, JsonElement value) in _buffer)
-                {
-                    _timeWriter.WritePropertyName(name);
-                    value.WriteTo(_timeWriter);
-                }
-                _timeWriter.WriteEndObject();
-            }
-            _buffer.Clear();
-        }
-
-        private static JsonElement NewJsonElement(Guid value) => JsonSerializer.SerializeToElement(value.ToString("D"));
-
-        private JsonElement JsonElementGUID(string value) => NewJsonElement(_finalGuid.GetGuid(value));
-
-        private void ParseJsonArray(JsonElement rootElement)
+        private void WriteJsonElement(string entityName, DataFileWriter currentWriter, JsonElement rootElement)
         {
             if (rootElement.ValueKind != JsonValueKind.Array)
                 throw new InvalidDataException("[ParseJsonArray]: [First element] not is JsonValueKind.Array");
@@ -159,11 +48,81 @@ namespace Infrastructure.Postgres.Seeding.SeedDataFiles
                 if (jsonObject.ValueKind != JsonValueKind.Object)
                     throw new InvalidDataException("[ParseJsonArray]: In JsonArray not only JsonValueKind.Object");
 
-                if (_actionsForJsonObject == null)
-                    throw new InvalidOperationException("[ParseJsonArray]: Not set jsonObjectAction before call");
+                (bool isCorrectRec, List<(string Name, JsonElement Value)>? buffer) rez = GenerateJsonObject(entityName, jsonObject);
 
-                _actionsForJsonObject(jsonObject);
+                if (rez.isCorrectRec)
+                    currentWriter.WriteJsonObject(rez.buffer!);
             }
         }
+
+        private (bool isCorrectRec, List<(string Name, JsonElement Value)>? buffer) GenerateJsonObject(string entityName,
+            JsonElement jsonObject)
+        {
+            var seedFilesChecker = new HelperSeedFilesChecker(entityName);
+            List<(string Name, JsonElement Value)> buffer = new();
+
+            // цикл по полям объекта
+            foreach (JsonProperty property in jsonObject.EnumerateObject())
+            {
+                JsonElement jsonValue = property.Value;
+
+                if (jsonValue.ValueKind == JsonValueKind.Object || jsonValue.ValueKind == JsonValueKind.Array)
+                {
+                    buffer.Add((property.Name, jsonValue));
+                    continue;
+                }
+
+                string value = jsonValue.ToString();
+                var typeKey = seedFilesChecker?.GetKeyType(value);
+
+                switch (typeKey)
+                {
+                    case TypeKey.NotKey:
+                        buffer.Add((property.Name, jsonValue));
+                        continue;
+
+                    case TypeKey.PK:
+                        if (_existPKeys.Contains(value))
+                        {
+                            // skip rec with dublicate PKeys
+                            return (false, null);
+                        }
+                        else
+                        {
+                            _existPKeys.Add(value);
+                            buffer.Add((property.Name, NewJsonElement(_finalGuid.GetGuid(value))));
+                            continue;
+                        }
+
+                    case TypeKey.FK:
+                        if (_finalGuid.TryGetGuid(value, out Guid guid))
+                        {
+                            buffer.Add((property.Name, NewJsonElement(guid)));
+                            continue;
+                        }
+                        else
+                        {
+                            // skip rec with FK which not exist in dict PKeys
+                            return (false, null);
+                        }
+                }
+            }
+
+            return (true, buffer);
+        }
+
+        private string GetNameCurrentDataFile(ReadOnlySpan<char> name)
+        {
+            if (name.Length == 0)
+                throw new InvalidOperationException("Entity name cannot be empty.");
+
+            string Name = name.Length == 1
+                ? char.ToUpperInvariant(name[0]).ToString()
+                : string.Concat(char.ToUpperInvariant(name[0]), name[1..].ToString());
+
+            return $"Demo{Name}.json";
+        }
+
+        private static JsonElement NewJsonElement(Guid value) => JsonSerializer.SerializeToElement(value.ToString("D"));
     }
 }

--- a/src/backend/Infrastructure.Postgres/Seeding/SeedDataFiles/SeedUUIDState.cs
+++ b/src/backend/Infrastructure.Postgres/Seeding/SeedDataFiles/SeedUUIDState.cs
@@ -1,0 +1,10 @@
+﻿using Infrastructure.Postgres.Seeding.Shared;
+
+namespace Infrastructure.Postgres.Seeding.SeedDataFiles;
+
+public class SeedUUIDState
+{
+    public UUIDMode UUIDMode { get; set; } = default!;
+    public bool ManualControl { get; set; } = default!; //IsOptionsUnderFullManualControl
+    public DateTime LastSeedUtc { get; set; }
+}

--- a/src/backend/Infrastructure.Postgres/Seeding/SeedDataFiles/SeedUUIDStateChecker.cs
+++ b/src/backend/Infrastructure.Postgres/Seeding/SeedDataFiles/SeedUUIDStateChecker.cs
@@ -1,0 +1,95 @@
+﻿using Infrastructure.Postgres.Seeding.Shared;
+using Microsoft.Extensions.Logging;
+using System.Text.Json;
+
+namespace Infrastructure.Postgres.Seeding.SeedDataFiles
+{
+    internal class SeedUUIDStateChecker
+    {
+        private const string FILENAME = "SeedUUIDState.json";
+
+        private readonly ILogger _log;
+        private readonly OptionsResult _opt;
+        private readonly bool _isOptionsUnderFullManualControl;
+
+        public SeedUUIDStateChecker(ILogger log, OptionsResult options, bool isOptionsUnderFullManualControl)
+        {
+            _log = log;
+            _opt = options;
+            _isOptionsUnderFullManualControl = isOptionsUnderFullManualControl;
+        }
+
+        internal OptionsResult FreshExistenDataIfNeed()
+        {
+            var stateFile = GetFileName();
+
+            SeedUUIDState? stateStored = null;
+
+            if (File.Exists(stateFile))
+            {
+                var json = File.ReadAllText(stateFile);
+                stateStored = JsonSerializer.Deserialize<SeedUUIDState>(json);
+            }
+
+            var isMissingState = stateStored is null;
+            var isUuidChanged = stateStored is not null && stateStored.UUIDMode != CurrentConfigUUID;
+            var isManualToPreset = stateStored is not null && stateStored.ManualControl == true && !_isOptionsUnderFullManualControl;
+            var isCanContainInconsistentData = isUuidChanged || isManualToPreset;
+
+            if (_opt.ExistenData == ExistenData.Fresh)
+                return _opt;
+
+            if (_isOptionsUnderFullManualControl && (isMissingState || isCanContainInconsistentData))
+            {
+                _log.LogWarning(
+                    "Seed UUID state is missing or UUID mode changed for current DbContext while ExistenData=NotDel. " +
+                    "Manual mode: existing data consistency cannot be validated.");
+
+                return _opt; // ничего не меняем только LogWarning
+            }
+
+            if (!_isOptionsUnderFullManualControl && _opt.ExistenData != ExistenData.Fresh)
+            {
+                if (isCanContainInconsistentData)
+                {
+                    // риск "InconsistentData" - UUID реально поменялся / был ручной сид раньше
+                    _log.LogWarning(
+                        "Detected UUID mode change or previous manual-control seeding for current DbContext. " +
+                        "ExistenData is enforced to Fresh once to rebuild compatible data.");
+
+                    return _opt with { ExistenData = ExistenData.Fresh };
+                }
+
+                if (isMissingState)
+                {
+                    // Нет state-файла → считаем, что это первый запуск пресета либо возможность что раньше было InconsistentData
+                    _log.LogInformation(
+                        "Seed UUID state not found for current DbContext, unable to verify previous state. " +
+                        "ExistenData is enforced to Fresh once to initialize a consistent seed state.");
+
+                    return _opt with { ExistenData = ExistenData.Fresh };
+                }
+            }
+
+            return _opt;
+        }
+
+        // после успешного сидирования — обновляем SeedUUIDUsedState.json
+        internal void StoreCurrentUsedSeedUUID()
+        {
+            var newState = new SeedUUIDState
+            {
+                UUIDMode = CurrentConfigUUID,
+                ManualControl = _isOptionsUnderFullManualControl,
+                LastSeedUtc = DateTime.UtcNow
+            };
+
+            File.WriteAllText(GetFileName(),
+                JsonSerializer.Serialize(newState, new JsonSerializerOptions { WriteIndented = true }));
+        }
+
+        private UUIDMode CurrentConfigUUID => _opt.UUIDmode;  // "Real" / "Stable"
+
+        private string GetFileName() => Path.Combine(_opt.PathBase, FILENAME);
+    }
+}

--- a/src/backend/Infrastructure.Postgres/Seeding/SeedDataFiles/TableAnalysis.cs
+++ b/src/backend/Infrastructure.Postgres/Seeding/SeedDataFiles/TableAnalysis.cs
@@ -5,19 +5,16 @@ namespace Infrastructure.Postgres.Seeding.SeedDataFiles;
 internal sealed class TableAnalysis
 {
     public IReadOnlyDictionary<string, Guid> PKeys { get; }
-    public IReadOnlySet<(string fKey, string fileName)> FKeys { get; }
     public IReadOnlyCollection<(string entityName, JsonElement rootElement)> RootJsonElementsEntities { get; }
     public IReadOnlyCollection<string> ValidationWarnings { get; }
 
     public bool IsValidationWarningsExist => ValidationWarnings.Count > 0;
 
     internal TableAnalysis(IReadOnlyDictionary<string, Guid> dictPKeyGuid,
-                        IReadOnlySet<(string fKey, string fileName)> hashFKeyFileName,
                         IReadOnlyCollection<(string entityName, JsonElement rootElement)> rootJsonElementsEntities,
                         IReadOnlyCollection<string> validationWarnings)
     {
         PKeys = dictPKeyGuid;
-        FKeys = hashFKeyFileName;
         RootJsonElementsEntities = rootJsonElementsEntities;
         ValidationWarnings = validationWarnings;
     }

--- a/src/backend/Infrastructure.Postgres/Seeding/SeedPresetAnalyzer.cs
+++ b/src/backend/Infrastructure.Postgres/Seeding/SeedPresetAnalyzer.cs
@@ -1,0 +1,78 @@
+﻿using Infrastructure.Postgres.Seeding.Shared;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace Infrastructure.Postgres.Seeding;
+
+internal sealed class SeedPresetAnalyzer
+{
+    private const string _prefixSeedMode = "Seed:Preset";
+
+    private readonly ILogger _log;
+    private readonly IConfiguration _cfg;
+
+    private SeedPreset _seedPreset = SeedPreset.SeedCustom;
+
+    public SeedPresetAnalyzer(ILogger<SeedPresetAnalyzer> log, IConfiguration cfg)
+    {
+        _log = log;
+        _cfg = cfg;
+    }
+
+    internal OptionsResult ApplySeedPreset(OptionsResult optRez)
+    {
+        if (IsOptionsUnderFullManualControl)
+            return optRez;
+
+        return _seedPreset switch
+        {
+            SeedPreset.SuperFast => optRez with
+            {
+                UUIDmode = UUIDMode.Stable,
+                ExistenData = ExistenData.NotDel,
+                InsertMode = SeedInsertMode.InsertOnly,
+                AutoMigrate = true
+            },
+
+            SeedPreset.Fast => optRez with
+            {
+                UUIDmode = UUIDMode.Stable,
+                ExistenData = ExistenData.NotDel,
+                InsertMode = SeedInsertMode.InsertOrUpdate,
+                AutoMigrate = true
+            },
+
+            SeedPreset.Real => optRez with
+            {
+                UUIDmode = UUIDMode.Real,
+                ExistenData = ExistenData.Fresh,
+                InsertMode = SeedInsertMode.InsertOnly,
+                AutoMigrate = true
+            },
+
+            // SeedPreset.SeedOFF должно обрабатываться в самом начале через GetAndCheckIsSeedOff()
+            _ => throw new NotImplementedException($"Not support [{_seedPreset}] preset or error in logic")
+        };
+    }
+
+    internal bool IsOptionsUnderFullManualControl => _seedPreset == SeedPreset.SeedCustom;
+
+    internal bool GetAndCheckIsSeedOff()
+    {
+        _seedPreset = GetSeedPreset();
+
+        _log.LogInformation("Seeding Preset={seedPreset}", _seedPreset);
+
+        return _seedPreset == SeedPreset.SeedOFF;
+    }
+
+    private SeedPreset GetSeedPreset()
+    {
+        var seedPresetText = _cfg[_prefixSeedMode];
+
+        if (!Enum.TryParse(seedPresetText, ignoreCase: true, out SeedPreset seedPreset))
+            return SeedPreset.SeedCustom;
+
+        return seedPreset;
+    }
+}

--- a/src/backend/Infrastructure.Postgres/Seeding/Seeders/BaseSeeder.cs
+++ b/src/backend/Infrastructure.Postgres/Seeding/Seeders/BaseSeeder.cs
@@ -80,7 +80,7 @@ internal abstract class BaseSeeder<TContext, TEntity, TDto> : ISeeder<TContext> 
         return (true, null);
     }
 
-    public async Task<(bool, string?)> SeedAsync(TContext dbContext, SeedMode mode, CancellationToken ct = default)
+    public async Task<(bool, string?)> SeedAsync(TContext dbContext, SeedInsertMode mode, CancellationToken ct = default)
     {
         if (_demoData is null)
             throw new SeederDataException("SeedAsync called without prior successful LoadAndValidateAsync.");
@@ -95,7 +95,7 @@ internal abstract class BaseSeeder<TContext, TEntity, TDto> : ISeeder<TContext> 
             }
             else
             {
-                if (mode == SeedMode.InsertOnly) continue;
+                if (mode == SeedInsertMode.InsertOnly) continue;
                 UpdateEntity(entity, recDemo);
             }
         }

--- a/src/backend/Infrastructure.Postgres/Seeding/Shared/ISeeder.cs
+++ b/src/backend/Infrastructure.Postgres/Seeding/Shared/ISeeder.cs
@@ -13,7 +13,7 @@ internal interface ISeeder<TContext> where TContext : DbContext
 
     Task<(bool ok, string? errorMsg)> LoadAndValidateAsync(string pathDemoDataFile, CancellationToken ct = default);
 
-    Task<(bool ok, string? errorMsg)> SeedAsync(TContext db, SeedMode mode, CancellationToken ct = default);
+    Task<(bool ok, string? errorMsg)> SeedAsync(TContext db, SeedInsertMode mode, CancellationToken ct = default);
 
     Task<(bool ok, string? errorMsg)> RemoveRecordsAsync(TContext dbContext, CancellationToken ct = default);
 

--- a/src/backend/Infrastructure.Postgres/Seeding/Shared/OptionsResult.cs
+++ b/src/backend/Infrastructure.Postgres/Seeding/Shared/OptionsResult.cs
@@ -1,5 +1,5 @@
 ﻿namespace Infrastructure.Postgres.Seeding.Shared;
 
-internal sealed record OptionsResult(bool Ok, ExistenData ExistenData, SeedMode Mode, string PathBase,
-    string PathVersion, bool AutoMigrate, string? Error = null)
+internal sealed record OptionsResult(bool Ok, ExistenData ExistenData, SeedInsertMode InsertMode, string PathBase,
+    string PathVersion, bool AutoMigrate, UUIDMode UUIDmode, string? Error = null)
     : PhaseResult(Ok, Error);

--- a/src/backend/Infrastructure.Postgres/Seeding/Shared/SeedInsertMode.cs
+++ b/src/backend/Infrastructure.Postgres/Seeding/Shared/SeedInsertMode.cs
@@ -1,0 +1,3 @@
+﻿namespace Infrastructure.Postgres.Seeding.Shared;
+
+public enum SeedInsertMode { InsertOnly, InsertOrUpdate }

--- a/src/backend/Infrastructure.Postgres/Seeding/Shared/SeedMode.cs
+++ b/src/backend/Infrastructure.Postgres/Seeding/Shared/SeedMode.cs
@@ -1,3 +1,0 @@
-﻿namespace Infrastructure.Postgres.Seeding.Shared;
-
-public enum SeedMode { InsertOnly, InsertOrUpdate }

--- a/src/backend/Infrastructure.Postgres/Seeding/Shared/SeedPreset.cs
+++ b/src/backend/Infrastructure.Postgres/Seeding/Shared/SeedPreset.cs
@@ -1,0 +1,17 @@
+﻿namespace Infrastructure.Postgres.Seeding.Shared;
+
+/// <summary>
+/// <para>SeedOFF     - сидирование полностью отключено</para>
+/// <para>SeedCustom  - ручное управление всеми опциями</para>
+/// <para>SuperFast   - UUID=STABLE, ExistenData=NotDel, InsertMode=InsertOnly, AutoMigrate=true</para>
+/// <para>Fast        - UUID=STABLE, ExistenData=NotDel, InsertMode=InsertOrUpdate, AutoMigrate=true</para>
+/// <para>Real        - UUID=Real, ExistenData=Fresh, InsertMode=InsertOnly, AutoMigrate=true</para>
+/// </summary>
+public enum SeedPreset
+{
+    SeedOFF,
+    SeedCustom,
+    SuperFast,
+    Fast,
+    Real
+}

--- a/src/backend/Infrastructure.Postgres/Time/SeedData/DemoCars.seed.json
+++ b/src/backend/Infrastructure.Postgres/Time/SeedData/DemoCars.seed.json
@@ -24,9 +24,15 @@
     "RegNumber": "Н 013 КВ 57"
   },
   {
+    "Id": "!cars.5",
+    "Model": "Volga",
+    "Owner": "!tester.99",
+    "RegNumber": "Н 013 КВ 57"
+  },
+  {
     "Id": "!cars.4",
     "Model": "Hyundai Tucson",
-    "Owner": "!tester.99",
+    "Owner": "!tester.1",
     "RegNumber": "Н 013 КВ 57"
   }
 ]

--- a/tests/Infrastructure.UnitTests/Seeding/ApprovalTests/Snapshot_Create_Tests.Inputs_snapshot_is_approved.DemoCars.seed.json.verified.txt
+++ b/tests/Infrastructure.UnitTests/Seeding/ApprovalTests/Snapshot_Create_Tests.Inputs_snapshot_is_approved.DemoCars.seed.json.verified.txt
@@ -24,9 +24,15 @@
     "RegNumber": "Н 013 КВ 57"
   },
   {
+    "Id": "!cars.5",
+    "Model": "Volga",
+    "Owner": "!tester.99",
+    "RegNumber": "Н 013 КВ 57"
+  },
+  {
     "Id": "!cars.4",
     "Model": "Hyundai Tucson",
-    "Owner": "!tester.99",
+    "Owner": "!tester.1",
     "RegNumber": "Н 013 КВ 57"
   }
 ]

--- a/tests/Infrastructure.UnitTests/SeedingTestData/DemoCars.seed.json
+++ b/tests/Infrastructure.UnitTests/SeedingTestData/DemoCars.seed.json
@@ -24,9 +24,15 @@
     "RegNumber": "Н 013 КВ 57"
   },
   {
+    "Id": "!cars.5",
+    "Model": "Volga",
+    "Owner": "!tester.99",
+    "RegNumber": "Н 013 КВ 57"
+  },
+  {
     "Id": "!cars.4",
     "Model": "Hyundai Tucson",
-    "Owner": "!tester.99",
+    "Owner": "!tester.1",
     "RegNumber": "Н 013 КВ 57"
   }
 ]


### PR DESCRIPTION
Summary:
Устранение дублей PKeys, обновление Approval-тестов и дальнейший рефакторинг компонентов анализа и генерации SeedFiles для более устойчивого пайплайна. А также Refactoring seeding options

Исправление проблемы дублирующихся PKeys и обновление пайплайна сидирования:
- Исправлена логика предотвращения создания дублирующихся PKeys
- Добавлен Approval Test для проверки отсутствия дублей PKeys
- Обновлён snapshot для тестов
- В DemoCars.seed.json добавлен демонстрационный случай с дублирующимися PKeys

Refactoring SeedFilesOutputGenerator:
- Упрощение внутренней логики
- Выделение функциональности записи файлов в отдельный компонент DataFileWriter
- Изменена логика исключения некорректных FKeys (без соответствующих PKeys)

Refactoring SeedFilesAnalyzer:
- Исправлено имя метода — DetectedWarnings
- Удалено копирование неиспользуемых данных в TableAnalysis

Refactoring seeding options InsertMode и UUID
- Изменения найминга опции InsertMode (раньше Mode) = InsertOnly/InsertOrUpdate
- Активация опции UUID (Stable/Real)

Refactoring  системы управления опциями сидирования с учет взаимовлияния опций.
- Добавлены пресеты (SeedMode) для упрощённого управления наборами опций.
- Добавлена проверка изменения режима UUID (Real <-> Stable), которое может приводить к несовместимости существующих данных (предупреждения или принудительного удаления старых несовместимых данных в зависимости от режима "ручной/авто")