### PR TITLE
Chore: создание EmptyDb-инфраструктуры для интеграционных API-тестов

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,6 +8,7 @@
     <PackageVersion Include="FluentAssertions.Json" Version="8.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.1" />
     <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.4" />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.4" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="8.0.4" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -40,7 +41,7 @@
     <PackageVersion Include="xunit.extensibility.execution" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-	<PackageVersion Include="coverlet.collector" Version="6.0.0" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.4" />
   </ItemGroup>
 </Project>

--- a/src/backend/Api/ApiConfigurations.cs
+++ b/src/backend/Api/ApiConfigurations.cs
@@ -13,8 +13,14 @@ public static class ApiConfigurations
         // при спец-флаге загружаем Test-оверрайды
         if (Environment.GetEnvironmentVariable("WC_USE_TEST_SETTINGS") == "true")
         {
-            builder.Configuration
-                .AddJsonFile("appsettings.IntegrationTests.json", optional: true, reloadOnChange: true);
+            if (Environment.GetEnvironmentVariable("WC_TEST_EMPTY_DB") == "true")
+            {
+                builder.Configuration.AddJsonFile("appsettings.IntegrationTestsEmptyDb.json", optional: true, reloadOnChange: true); 
+            }
+            else
+            {
+                builder.Configuration.AddJsonFile("appsettings.IntegrationTests.json", optional: true, reloadOnChange: true);
+            }
         }
 
         return builder;

--- a/src/backend/Api/appsettings.IntegrationTestsEmptyDb.json
+++ b/src/backend/Api/appsettings.IntegrationTestsEmptyDb.json
@@ -1,0 +1,14 @@
+{
+  // Configuration overrides for integration tests ONLY.
+  // This file is NOT a full configuration and does NOT define a separate environment.
+  // It is applied conditionally via WC_USE_TEST_SETTINGS=true & WC_TEST_EMPTY_DB == true, on top of appsettings.json.
+  "Seed": {
+    "Preset": "EmptyDb",
+    "MainDbContext": {
+      "Enabled": true
+    },
+    "TimeDbContext": {
+      "Enabled": false
+    }
+  }
+}

--- a/src/backend/Api/appsettings.json
+++ b/src/backend/Api/appsettings.json
@@ -7,7 +7,7 @@
   },
   "AllowedHosts": "*",
   "Seed": {
-    "Preset": "SeedCustom", // "SeedOFF", "SeedCustom", "SuperFast", "Fast", "Real"
+    "Preset": "SeedCustom", // "SeedOFF", "SeedCustom", "SuperFast", "Fast", "Real", "EmptyDb"
     "CoreOption": {
       "FileNameDataTemplate": "Demo{Entity}.json", // Пример для сущности Tester "DemoTester.json"
       "FileNameSeedTemplate": "Demo{Entity}.seed.json", // Пример для сущности Tester "DemoTester.seed.json"

--- a/src/backend/Infrastructure.Postgres/Seeding/ContextDB/Checker.cs
+++ b/src/backend/Infrastructure.Postgres/Seeding/ContextDB/Checker.cs
@@ -60,13 +60,13 @@ internal class Checker<TContext> where TContext : DbContext
         {
             var canConnect = await _db.Database.CanConnectAsync(ct);
             if (!canConnect)
-                _log.LogError($"Cannot connect to database: {_db.Database.GetDbConnection().Database}.");
+                _log.LogError("Cannot connect to database: {Database}", _db.Database.GetDbConnection().Database);
 
             return canConnect;
         }
         catch (Exception ex)
         {
-            _log.LogError(ex, $"Error while checking connection for {_db.Database.GetDbConnection().Database}");
+            _log.LogError(ex, "Error while checking connection for {Database}", _db.Database.GetDbConnection().Database);
             return false;
         }
     }

--- a/src/backend/Infrastructure.Postgres/Seeding/ContextDB/Migrate.cs
+++ b/src/backend/Infrastructure.Postgres/Seeding/ContextDB/Migrate.cs
@@ -33,7 +33,7 @@ internal class Migrate<TContext> where TContext : DbContext
         }
         catch (Exception ex)
         {
-            _log.LogError(ex, $"Error while Migration for {_db.Database.GetDbConnection().Database}");
+            _log.LogError(ex, "Error while Migration for {Database}", _db.Database.GetDbConnection().Database);
             return false;
         }
     }

--- a/src/backend/Infrastructure.Postgres/Seeding/RunnerContextDB.cs
+++ b/src/backend/Infrastructure.Postgres/Seeding/RunnerContextDB.cs
@@ -19,16 +19,19 @@ internal sealed class RunnerContextDB<TContext> : IDbContextRunner where TContex
     private readonly ILogger _logSeeder;
     private readonly IConfiguration _cfg;
     private readonly string _prefix;
+    private readonly SeedPresetAnalyzer _seedPresetAnalyzer;
 
     private bool IsEnabledDbContextSeeding() => _cfg.GetValue(_prefix + "Enabled", false);
 
-    public RunnerContextDB(IServiceProvider serviceProvider, IConfiguration cfg, ILoggerFactory lf)
+    public RunnerContextDB(IServiceProvider serviceProvider, IConfiguration cfg, ILoggerFactory lf,
+        SeedPresetAnalyzer seedPresetAnalyzer)
     {
         _serviceProvider = serviceProvider;
         _cfg = cfg;
         string nameDbContext = typeof(TContext).Name;
         _prefix = $"Seed:{nameDbContext}:";
         _logSeeder = lf.CreateLogger($"Seeding{nameDbContext}");
+        _seedPresetAnalyzer = seedPresetAnalyzer;
     }
 
     public async Task<bool> RunAsync(CancellationToken ct = default)
@@ -41,6 +44,16 @@ internal sealed class RunnerContextDB<TContext> : IDbContextRunner where TContex
             return false;
         }
 
+        if (_seedPresetAnalyzer.UseEmptyDB)
+        {
+            bool migrationRez = await MadeMigration(ct);
+            if (!migrationRez)
+                return AbortDbContextNotReady();
+
+            _logSeeder.LogInformation("Set EmptyDB для [{DbContext}]", typeof(TContext).Name);
+            return true;
+        }
+
         var checkerOption = new Options<TContext>(_logSeeder, _cfg, _prefix);
         var optRez = checkerOption.CheckAndGet();
         if (!optRez.Ok)
@@ -49,8 +62,7 @@ internal sealed class RunnerContextDB<TContext> : IDbContextRunner where TContex
             return false;
         }
 
-        var seedPresetAnalyzer = _serviceProvider.GetRequiredService<SeedPresetAnalyzer>(); ;
-        optRez = seedPresetAnalyzer.ApplySeedPreset(optRez);
+        optRez = _seedPresetAnalyzer.ApplySeedPreset(optRez);
 
         var runnerSeedDataFiles = new RunnerSeedDataFiles(_logSeeder);
         var rezOk = runnerSeedDataFiles.Run(optRez.PathBase, optRez.UUIDmode);
@@ -70,9 +82,7 @@ internal sealed class RunnerContextDB<TContext> : IDbContextRunner where TContex
         {
             if (optRez.AutoMigrate)
             {
-                var migrator = ActivatorUtilities.CreateInstance<Migrate<TContext>>(_serviceProvider, _logSeeder);
-                await migrator.Run(ct);
-                dbContextRez = true;
+                dbContextRez = await MadeMigration(ct);
             }
             else
             {
@@ -82,12 +92,9 @@ internal sealed class RunnerContextDB<TContext> : IDbContextRunner where TContex
         }
 
         if (!dbContextRez)
-        {
-            _logSeeder.LogError("Abort Seeding. DbContext not Ready.");
-            return false;
-        }
+            return AbortDbContextNotReady();
 
-        var seedUUIDStateChecher = new SeedUUIDStateChecker(_logSeeder, optRez, seedPresetAnalyzer.IsOptionsUnderFullManualControl);
+        var seedUUIDStateChecher = new SeedUUIDStateChecker(_logSeeder, optRez, _seedPresetAnalyzer.IsOptionsUnderFullManualControl);
         optRez = seedUUIDStateChecher.FreshExistenDataIfNeed();
 
         if (optRez.ExistenData == ExistenData.Fresh)
@@ -102,5 +109,17 @@ internal sealed class RunnerContextDB<TContext> : IDbContextRunner where TContex
         seedUUIDStateChecher.StoreCurrentUsedSeedUUID();
 
         return true;
+    }
+
+    private bool AbortDbContextNotReady()
+    {
+        _logSeeder.LogError("Abort Seeding. DbContext not Ready.");
+        return false;
+    }
+
+    private async Task<bool> MadeMigration(CancellationToken ct)
+    {
+        var migrator = ActivatorUtilities.CreateInstance<Migrate<TContext>>(_serviceProvider, _logSeeder);
+        return await migrator.Run(ct);
     }
 }

--- a/src/backend/Infrastructure.Postgres/Seeding/SeedPresetAnalyzer.cs
+++ b/src/backend/Infrastructure.Postgres/Seeding/SeedPresetAnalyzer.cs
@@ -13,6 +13,8 @@ internal sealed class SeedPresetAnalyzer
 
     private SeedPreset _seedPreset = SeedPreset.SeedCustom;
 
+    public bool UseEmptyDB => _seedPreset == SeedPreset.EmptyDb;
+
     public SeedPresetAnalyzer(ILogger<SeedPresetAnalyzer> log, IConfiguration cfg)
     {
         _log = log;
@@ -50,7 +52,7 @@ internal sealed class SeedPresetAnalyzer
                 AutoMigrate = true
             },
 
-            // SeedPreset.SeedOFF должно обрабатываться в самом начале через GetAndCheckIsSeedOff()
+            // SeedPreset.SeedOFF & .UseEmptyDB должно обрабатываться до вызова ApplySeedPreset(...)
             _ => throw new NotImplementedException($"Not support [{_seedPreset}] preset or error in logic")
         };
     }

--- a/src/backend/Infrastructure.Postgres/Seeding/Shared/SeedPreset.cs
+++ b/src/backend/Infrastructure.Postgres/Seeding/Shared/SeedPreset.cs
@@ -6,6 +6,7 @@
 /// <para>SuperFast   - UUID=STABLE, ExistenData=NotDel, InsertMode=InsertOnly, AutoMigrate=true</para>
 /// <para>Fast        - UUID=STABLE, ExistenData=NotDel, InsertMode=InsertOrUpdate, AutoMigrate=true</para>
 /// <para>Real        - UUID=Real, ExistenData=Fresh, InsertMode=InsertOnly, AutoMigrate=true</para>
+/// <para>EmptyDb     - система сидирования только для создания таблиц без импорта демоданных</para>
 /// </summary>
 public enum SeedPreset
 {
@@ -13,5 +14,6 @@ public enum SeedPreset
     SeedCustom,
     SuperFast,
     Fast,
-    Real
+    Real,
+    EmptyDb
 }

--- a/tests/Api.UnitTests/Api.UnitTests.csproj
+++ b/tests/Api.UnitTests/Api.UnitTests.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
 	<FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="AutoFixture.AutoMoq" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
 	<PackageReference Include="coverlet.collector" />

--- a/tests/Api.UnitTests/Integration/CoursesController_GetAll_Tests_Testcontainers.cs
+++ b/tests/Api.UnitTests/Integration/CoursesController_GetAll_Tests_Testcontainers.cs
@@ -1,6 +1,10 @@
 ﻿using Api.UnitTests.Integration.Shared;
 using Application.DtoCourse;
+using Application.Models;
 using FluentAssertions;
+using Infrastructure.Postgres.Main;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
 using System.Net;
 using System.Text.Json;
 
@@ -10,7 +14,8 @@ namespace Api.UnitTests.Integration;
 public class CoursesController_GetAll_Tests_Testcontainers
 {
     private readonly HttpClient _client;
-
+    private readonly WebApplicationFactory<Program> _factory;
+    private readonly ContainerDbFixture _testcontainerFixture;
     private static JsonSerializerOptions _jsonOptions = new JsonSerializerOptions
     {
         PropertyNameCaseInsensitive = true
@@ -18,19 +23,22 @@ public class CoursesController_GetAll_Tests_Testcontainers
 
     public CoursesController_GetAll_Tests_Testcontainers(ContainerDbFixture testcontainerFixture)
     {
-        if (testcontainerFixture.Client is not null)
+        if (testcontainerFixture.Client is not null && testcontainerFixture.Factory is not null)
         {
             _client = testcontainerFixture.Client;
+            _factory = testcontainerFixture.Factory;
         }
         else
             throw new NotImplementedException();
+
+        _testcontainerFixture = testcontainerFixture;
     }
 
     [Fact]
-    public async Task GetAll_returns_200_and_valid_payload()
+    public async Task GetAll_Smoke_CleanDb_Returns_EmptyList()
     {
-        // Arrange in TestMainDbFixture
-
+        // No Arrange Empty DB
+        await _testcontainerFixture.ResetMainDbAsync();
         // Act
         var response = await _client.GetAsync("/api/courses");
 
@@ -41,6 +49,42 @@ public class CoursesController_GetAll_Tests_Testcontainers
 
         var dto = JsonSerializer.Deserialize<IEnumerable<CourseDto>>(json, _jsonOptions);
 
-        dto.Should().HaveCountGreaterThan(1);
+        dto.Should().NotBeNull();
+        dto.Should().HaveCount(0);
+    }
+
+    [Fact]
+    public async Task GetAllLecturesByCourseIdOrdered_ReturnsOrderedByOrderNo()
+    {
+        // Arrange
+        await _testcontainerFixture.ResetMainDbAsync();
+
+        using var scope = _factory.Services.CreateScope();
+        var mainDbContext = scope.ServiceProvider.GetRequiredService<MainDbContext>();
+
+        var courseId = "course-test-1";
+
+        mainDbContext.Courses.Add(new Course(courseId, "Test course", null));
+
+        mainDbContext.Lectures.AddRange(
+            new Lecture(Guid.NewGuid(), courseId, 2, "Lecture 2", null, null),
+            new Lecture(Guid.NewGuid(), courseId, 1, "Lecture 1", null, null)
+        );
+
+        await mainDbContext.SaveChangesAsync();
+
+        // Act
+        var response = await _client.GetAsync($"/api/courses/{courseId}/lectures");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var json = await response.Content.ReadAsStringAsync();
+
+        var dto = JsonSerializer.Deserialize<IEnumerable<LectureListItemDto>>(json, _jsonOptions);
+
+        dto.Should().NotBeNull();
+        dto.Should().HaveCount(2);
+        dto.Should().BeInAscendingOrder(lec => lec.OrderNo);
     }
 }

--- a/tests/Api.UnitTests/Integration/Shared/ContainerDbFixture.cs
+++ b/tests/Api.UnitTests/Integration/Shared/ContainerDbFixture.cs
@@ -1,6 +1,9 @@
 ﻿using DotNet.Testcontainers.Builders;
 using DotNet.Testcontainers.Configurations;
+using Infrastructure.Postgres.Main;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using Npgsql;
 using Testcontainers.PostgreSql;
 
@@ -10,8 +13,11 @@ public class ContainerDbFixture : IAsyncLifetime
 {
     private const string FILENAME_DB_LOG = "postgres_log.txt";
     private const int TIME_SEC_STOP_FROZZEN_CONTAINER = 15;
-    public HttpClient? Client;
+    private HttpClient? _client;
     private WebApplicationFactory<Program>? _factory;
+
+    public HttpClient? Client => _client;
+    public WebApplicationFactory<Program>? Factory => _factory;
 
     // 3. защита от зависаний
     private static readonly Action<IWaitStrategy> _waitStrategy = strategy
@@ -48,12 +54,41 @@ public class ContainerDbFixture : IAsyncLifetime
         await Container.StartAsync();
 
         _factory = new ContainerDbWebApplicationFactory(Container.GetConnectionString());
-        Client = _factory.CreateClient();
+        _client = _factory.CreateClient();
     }
-    
+
+    public async Task ResetMainDbAsync()
+    {
+        using var scope = _factory!.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MainDbContext>();
+
+        var conn = db.Database.GetDbConnection();
+        await conn.OpenAsync();
+
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = """
+        DO $$
+        DECLARE
+            r RECORD;
+        BEGIN
+            FOR r IN
+                SELECT tablename
+                FROM pg_tables
+                WHERE schemaname = 'main'
+            LOOP
+                EXECUTE format('TRUNCATE TABLE main.%I RESTART IDENTITY CASCADE', r.tablename);
+            END LOOP;
+        END
+        $$;
+        """;
+
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+
     public async Task DisposeAsync()
     {
-        Client?.Dispose();
+        _client?.Dispose();
         _factory?.Dispose();
 
         if (Container is not null)

--- a/tests/Api.UnitTests/Integration/Shared/ContainerDbWebApplicationFactory.cs
+++ b/tests/Api.UnitTests/Integration/Shared/ContainerDbWebApplicationFactory.cs
@@ -1,5 +1,10 @@
 ﻿using Api;
+using Api.UnitTests.Integration.Shared;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
 public class ContainerDbWebApplicationFactory : WebApplicationFactory<Program>
@@ -20,4 +25,21 @@ public class ContainerDbWebApplicationFactory : WebApplicationFactory<Program>
 
         return base.CreateHost(builder);
     }
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.ConfigureTestServices(services =>
+        {
+            services
+                .AddAuthentication()
+                .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(TestAuthHandler.SchemeName, _ => { });
+
+            services.PostConfigure<AuthenticationOptions>(o =>
+            {
+                o.DefaultAuthenticateScheme = TestAuthHandler.SchemeName;
+                o.DefaultChallengeScheme = TestAuthHandler.SchemeName;
+            });
+        });
+    }
+
 }

--- a/tests/Api.UnitTests/Integration/Shared/ContainerDbWebApplicationFactory.cs
+++ b/tests/Api.UnitTests/Integration/Shared/ContainerDbWebApplicationFactory.cs
@@ -14,6 +14,8 @@ public class ContainerDbWebApplicationFactory : WebApplicationFactory<Program>
     {
         Environment.SetEnvironmentVariable("WC_USE_TEST_SETTINGS", "true");
 
+        Environment.SetEnvironmentVariable("WC_TEST_EMPTY_DB", "true");
+
         Environment.SetEnvironmentVariable("ConnectionStrings__Default",_connectionString);
 
         return base.CreateHost(builder);

--- a/tests/Api.UnitTests/Integration/Shared/TestAuthHandler.cs
+++ b/tests/Api.UnitTests/Integration/Shared/TestAuthHandler.cs
@@ -1,0 +1,36 @@
+﻿using System.Security.Claims;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Api.UnitTests.Integration.Shared;
+
+public sealed class TestAuthHandler : AuthenticationHandler<AuthenticationSchemeOptions>
+{
+    public const string SchemeName = "TestAuth";
+
+    public TestAuthHandler(
+        IOptionsMonitor<AuthenticationSchemeOptions> options,
+        ILoggerFactory logger,
+        UrlEncoder encoder)
+        : base(options, logger, encoder)
+    {
+    }
+
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        var claims = new[]
+        {
+            new Claim(ClaimTypes.NameIdentifier, "test-user"),
+            new Claim(ClaimTypes.Name, "Integration Test User"),
+            new Claim(ClaimTypes.Role, "Student"), // если где-то есть [Authorize(Roles=...)]
+        };
+
+        var identity = new ClaimsIdentity(claims, SchemeName);
+        var principal = new ClaimsPrincipal(identity);
+        var ticket = new AuthenticationTicket(principal, SchemeName);
+
+        return Task.FromResult(AuthenticateResult.Success(ticket));
+    }
+}


### PR DESCRIPTION
### Реализовано

- Добавлен режим EmptyDb для интеграционных тестов:
  - выполняются только миграции;
  - сидирование данных отключено.

- Проведён рефакторинг ContainerDbFixture:
  - каждый тест запускается в отдельной чистой БД;
  - отдельный scope MainDbContext на тест;
  - добавлен TestAuthHandler для API-тестов с авторизацией.

### Acceptance Criteria (артефакты)

- Пресет EmptyDb доступен для интеграционных тестов.
- Миграции могут выполняться без сидирования данных.
- Интеграционные тесты отрефакторены и проходят в режиме EmptyDb:
  - GetAll_Smoke_CleanDb_Returns_EmptyList
  - GetAllLecturesByCourseIdOrdered_ReturnsOrderedByOrderNo (with TestAuthHandler )